### PR TITLE
enable pod security policy in GCP and Azure

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -22,6 +22,8 @@ resource "azurerm_kubernetes_cluster" "polkadot-{{ clusterName }}" {
     client_id     = var.client_id
     client_secret = var.client_secret
   }
+
+  enable_pod_security_policy = true
 }
 
 resource "azurerm_virtual_network" "polkadot-{{ clusterName }}" {

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -39,6 +39,10 @@ resource "google_container_cluster" "primary" {
 
   network = "${google_compute_network.network.self_link}"
   subnetwork = "${google_compute_subnetwork.subnetwork.self_link}"
+
+  pod_security_policy_config {
+    enabled = true
+  }
 }
 
 resource "google_compute_network" "network" {


### PR DESCRIPTION
Towards https://github.com/w3f/infrastructure/issues/146

Azure required to enable `PodSecurityPolicyPreview` following https://docs.microsoft.com/en-us/azure/aks/use-pod-security-policies