### PR TITLE
Add audi keys

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -6,7 +6,7 @@
     "loki-stack": "0.32.1",
     "matrixbot": "v1.0.1",
     "nginx-ingress": "1.33.4",
-    "polkadot": "v0.19.0",
+    "polkadot": "v0.20.0",
     "prometheus-node-exporter": "1.9.0",
     "prometheus-operator": "8.11.1",
     "substrate-telemetry": "v1.0.2"

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -106,6 +106,10 @@ async function create(config) {
 
   await db.save(config);
 
+  if (!config.environmentKeys) {
+    console.log(chalk.green(keysBanner(config.keys, config.nodeKeys)));
+  }
+
   console.log(chalk.yellow(`Waiting for nodes ready...`));
   try {
     const result = await cluster.waitReady();
@@ -118,10 +122,6 @@ async function create(config) {
   }
 
   console.log(chalk.green('Done'));
-
-  if (!config.environmentKeys) {
-    console.log(chalk.green(keysBanner(config.keys, config.nodeKeys)));
-  }
 
   /*
   if (config.type !== 'local') {
@@ -143,8 +143,8 @@ function keysBanner(keys, nodeKeys) {
   const starLine = `*******************************************************************************`
   let keysString = '';
   const keyTypes = crypto.keyTypes();
-  const nodes = keys[keyTypes[0]].length;
-  for (let counter = 0; counter < nodes; counter++) {
+  const totalKeys = keys[keyTypes[0]].length;
+  for (let counter = 0; counter < totalKEys; counter++) {
     keyTypes.forEach((type) => {
       keysString += `
 export POLKADOT_DEPLOYER_KEYS_${counter}_${type.toUpperCase()}_ADDRESS=${keys[type][counter].address}
@@ -153,7 +153,7 @@ export POLKADOT_DEPLOYER_KEYS_${counter}_${type.toUpperCase()}_SEED=${keys[type]
     });
   }
   let nodesString = '';
-  for (let counter = 0; counter < nodes; counter++) {
+  for (let counter = 0; counter < nodeKeys.length; counter++) {
     nodesString +=`
 export POLKADOT_DEPLOYER_NODE_KEYS_${counter}_KEY=${nodeKeys[counter].nodeKey}
 export POLKADOT_DEPLOYER_NODE_KEYS_${counter}_PEER_ID=${nodeKeys[counter].peerId}

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -144,7 +144,7 @@ function keysBanner(keys, nodeKeys) {
   let keysString = '';
   const keyTypes = crypto.keyTypes();
   const totalKeys = keys[keyTypes[0]].length;
-  for (let counter = 0; counter < totalKEys; counter++) {
+  for (let counter = 0; counter < totalKeys; counter++) {
     keyTypes.forEach((type) => {
       keysString += `
 export POLKADOT_DEPLOYER_KEYS_${counter}_${type.toUpperCase()}_ADDRESS=${keys[type][counter].address}

--- a/lib/actions/project/tpl/package.json
+++ b/lib/actions/project/tpl/package.json
@@ -10,6 +10,6 @@
   "license": "GPL-3.0",
   "dependencies": {
     "npx": "10.2.0",
-    "polkadot-deployer": "2.0.0"
+    "polkadot-deployer": "2.0.1"
   }
 }

--- a/lib/network/crypto.js
+++ b/lib/network/crypto.js
@@ -11,7 +11,8 @@ module.exports = {
       'session_grandpa',
       'session_babe',
       'session_imonline',
-      'session_parachain'
+      'session_parachain',
+      'session_audi'
     ];
   },
   keyTypes: () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-deployer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tool for deploying Polkadot nodes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We were reusing babe keys for authority discovery on polkadot charts when generating the chainspec, this PR allows proper generation of authority discovery keys; it also fixes how node keys are shown at the end of a run (all these changes only affect custom chainspecs).