### PR TITLE
implemented and deployed as expected

### DIFF
--- a/lib/clients/helm.js
+++ b/lib/clients/helm.js
@@ -105,7 +105,7 @@ class Helm {
         deps.push('ingress-nginx', 'cert-manager');
         if (this.config.monitoring && this.config.monitoring.enabled) {
           deps.push('kube-prometheus-stack', 'prometheus-node-exporter', 'grafana', 'loki-stack', 'matrixbot', 'substrate-alertrules');
-          if (index === 0) {
+          if (this._isSubstrateTelemetryServerRequired(index)) {
             deps.push('substrate-telemetry');
           }
         }
@@ -207,7 +207,7 @@ class Helm {
     }
     if (this.config.type !== 'local' && this.config.monitoring && this.config.monitoring.enabled) {
       values.monitoring = true;
-      values.telemetry = domain.telemetry(this.config.networkName, this.config.remote);
+      values.telemetry = domain.telemetry(this.config.networkName, this.config);
     }
     if (index === 0) {
       values.createBootnodeService = true;
@@ -385,9 +385,19 @@ class Helm {
     await this._installMatrixbot();
     await this._installSubstrateAlertrules();
 
-    if (index === 0) {
+    if (this._isSubstrateTelemetryServerRequired(index)){
       await this._installSubstrateTelemetry();
     }
+  }
+
+  _isSubstrateTelemetryServerRequired(index){
+    const telemetryConfig = this.config.monitoring.telemetry
+    if(!telemetryConfig){
+      return index === 0
+    }
+
+    const telemetryServerConfig = telemetryConfig.server
+    return telemetryServerConfig && telemetryServerConfig.enabled && index == telemetryServerConfig.clusterIndex
   }
 
   async _installPrometheusOperator() {

--- a/lib/network/domain.js
+++ b/lib/network/domain.js
@@ -1,15 +1,27 @@
 module.exports = {
-  default: (subdomain, remoteConfig, index=0) => {
+  default: (defaultSubdomain, remoteConfig, index=0) => {
     const base = module.exports.base(remoteConfig, index);
+
+    const subdomain = remoteConfig.clusters[index].subdomain || defaultSubdomain
 
     return `${subdomain}.${base}`;
   },
-  telemetry: (networkName, remoteConfig, index=0) => {
+  telemetry: (defaultNetworkName, config, index=0) => {
+    const remoteConfig = config.remote
     const base = module.exports.base(remoteConfig, index);
 
-    return `wss://telemetry-backend.${networkName}-0.${base}/submit`;
+    const telemetryNetworkSubdomain = module.exports._getTelemetryNetworkSubdomain(defaultNetworkName,config);
+    console.log(`telemetry: wss://telemetry-backend.${telemetryNetworkSubdomain}.${base}/submit`)
+
+    return `wss://telemetry-backend.${telemetryNetworkSubdomain}.${base}/submit`;
   },
   base: (remoteConfig, index=0) => {
     return remoteConfig.clusters[index].domain || remoteConfig.domain || "";
+  },
+  _getTelemetryNetworkSubdomain: (defaultNetworkName, config) => {
+    if(!config.monitoring || !config.monitoring.telemetry || !config.monitoring.telemetry.submit)
+      return `${defaultNetworkName}-0`
+
+    return config.monitoring.telemetry.submit.networkSubdomain
   }
 }

--- a/test/lib/network/domain.js
+++ b/test/lib/network/domain.js
@@ -16,7 +16,7 @@ describe('domain', () => {
   describe('telemetry', () => {
     it('should return the telemetry domain for the given config and cluster index', () => {
       const expected = 'wss://telemetry-backend.subdomain-0.domain.tld/submit';
-      const config = {clusters: [{domain: 'domain.tld'}]}
+      const config = {remote:{clusters: [{domain: 'domain.tld'}]}}
       const actual = subject.telemetry('subdomain', config);
 
       actual.should.eq(expected);


### PR DESCRIPTION
OPERATOR 1 - GP 1
```
{
  "name": "cc3-op1-gp1",
  "type": "gcp",
  "nodes": 1,
  "keep": true,
  "gcloudPath": "/usr/local/bin/gcloud",
  "monitoring": {
    "enabled": true,
    "telemetry": {
      "server": {
        "enabled": true,
        "clusterIndex": 0
      },
      "submit": {
        "networkSubdomain": "cc3-60"
      }
    },
    "opsgenie": {
      "enabled": false,
      "url": "https://api.eu.opsgenie.com/"
     }
  },
  "chainspec": {
    "custom": false,
    "preset": true,
    "name": "kusama"
  },
  "resources": {
    "requests": {
      "memory": "9Gi",
      "cpu": "1.5"
    }
  },
  "image": {
    "repo": "parity/polkadot",
    "tag": "v0.8.26-1"
  },
  "remote": {
    "projectID": "development-XXX",
    "domain": "kusama.network",
    "clusters": [
      {
        "provider": "gcp",
        "location": "europe-west6-a",
        "machineType": "n1-standard-4",
        "subdomain": "cc3-60"
      }
    ]
  }
}
```


OPERATOR 1 - GP 2
```
{
  "name": "cc3-op1-gp2",
  "type": "gcp",
  "nodes": 2,
  "keep": true,
  "gcloudPath": "/usr/local/bin/gcloud",
  "monitoring": {
    "enabled": true,
    "telemetry": {
      "server": {
        "enabled": false
      },
      "submit": {
        "networkSubdomain": "cc3-60"
      }
    },
    "opsgenie": {
      "enabled": false,
      "url": "https://api.eu.opsgenie.com/"
     }
  },
  "chainspec": {
    "custom": false,
    "preset": true,
    "name": "kusama"
  },
  "resources": {
    "requests": {
      "memory": "9Gi",
      "cpu": "1.5"
    }
  },
  "image": {
    "repo": "parity/polkadot",
    "tag": "v0.8.26-1"
  },
  "remote": {
    "projectID": "development-XXX",
    "domain": "kusama.network",
    "clusters": [
      {
        "provider": "gcp",
        "location": "europe-north1-a",
        "machineType": "n1-standard-4",
        "subdomain": "cc3-61"
      },
      {
        "provider": "gcp",
        "location": "europe-north1-a",
        "machineType": "n1-standard-4",
        "subdomain": "cc3-62"
      }
    ]
  }
}
```